### PR TITLE
Discontinue reference to quake-client 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to get started using the provider.
 ## Building the resources as stand-alone provider
 
 ```bash
-$ git clone https://github.com/HewlettPackard/hpegl-metal-terraform-resources.git
+$ git clone https://github.com/hewlettpackard/hpegl-metal-terraform-resources.git
 $ cd hpegl-metal-terraform-resources
 $ make build
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/HewlettPackard/hpegl-metal-terraform-resources
+module github.com/hewlettpackard/hpegl-metal-terraform-resources
 
 go 1.17
 
@@ -6,8 +6,8 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/hashicorp/terraform-plugin-docs v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
+	github.com/hewlettpackard/hpegl-metal-client v1.3.20-0.20220511202820-3b2ca9ca037a
 	github.com/hewlettpackard/hpegl-provider-lib v0.0.12
-	github.com/hpe-hcss/quake-client v1.3.19
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -181,7 +181,6 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deis/deis v1.13.4/go.mod h1:8wwLzvV6ikTNSIAIj8CTdkloCRGy7C3wMrkB3U00Nx8=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -240,9 +239,8 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
-github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0/go.mod h1:vrgyG+5Bxrnz4MZWPF+pI4R8h3qKRjjyvV/DSez4WVQ=
 github.com/go-toolsmith/astequal v1.0.0/go.mod h1:H+xSiq0+LtiDC11+h1G32h7Of5O3CYFJ99GVbS5lDKY=
@@ -480,11 +478,11 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hewlettpackard/hpegl-metal-client v1.3.20-0.20220511202820-3b2ca9ca037a h1:z783pvFzLrubX9U8gSYqhcn9ZlSVABkg+HKSbhTFOng=
+github.com/hewlettpackard/hpegl-metal-client v1.3.20-0.20220511202820-3b2ca9ca037a/go.mod h1:8YfuL0YfT5SWZK+5oAncDwiBfxqKwXDe9gvEJVhykL0=
 github.com/hewlettpackard/hpegl-provider-lib v0.0.12 h1:0c9seGoq34yDiQHv/wdLYEjaR9VCxR775dGdAxHo59k=
 github.com/hewlettpackard/hpegl-provider-lib v0.0.12/go.mod h1:IKqB5hzOz1zrrQloNP8Ux3j/8Kcq0UUcTRtJmJw7YQE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hpe-hcss/quake-client v1.3.19 h1:c3tRNZ+iF0UR9ya0EQq0jG3mQhuCl3ZAb9eTqCXaTk0=
-github.com/hpe-hcss/quake-client v1.3.19/go.mod h1:EE3DlMrIGmYGjPSzO92WDM1wpve6V0hzNty0xo7ETes=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -828,7 +826,6 @@ github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lP
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.8/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/uudashr/gocognit v1.0.5/go.mod h1:wgYz0mitoKOTysqxTDMOUXg+Jb5SvtihkfmugIZYpEA=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.30.0/go.mod h1:2rsYD01CKFrjjsvFxx75KlEUNpWNBY9JWD3K/7o2Cus=

--- a/internal/acceptance_test/provider_test.go
+++ b/internal/acceptance_test/provider_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	testutils "github.com/HewlettPackard/hpegl-metal-terraform-resources/internal/test-utils"
+	testutils "github.com/hewlettpackard/hpegl-metal-terraform-resources/internal/test-utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	libUtils "github.com/hewlettpackard/hpegl-provider-lib/pkg/utils"

--- a/internal/resources/datasource_available_resources.go
+++ b/internal/resources/datasource_available_resources.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/configuration"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/configuration"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 )
 
 const (

--- a/internal/resources/datasource_images.go
+++ b/internal/resources/datasource_images.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 func DataSourceImage() *schema.Resource {

--- a/internal/resources/datasource_usage.go
+++ b/internal/resources/datasource_usage.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/antihax/optional"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_host.go
+++ b/internal/resources/resource_host.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_ip.go
+++ b/internal/resources/resource_ip.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_network.go
+++ b/internal/resources/resource_network.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_network_test.go
+++ b/internal/resources/resource_network_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hpe-hcss/quake-client/pkg/terraform/configuration"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/configuration"
 )
 
 func TestAccQuakeNetwork(t *testing.T) {

--- a/internal/resources/resource_project.go
+++ b/internal/resources/resource_project.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_ssh_key.go
+++ b/internal/resources/resource_ssh_key.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_ssh_key_test.go
+++ b/internal/resources/resource_ssh_key_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hpe-hcss/quake-client/pkg/terraform/configuration"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/configuration"
 )
 
 func quatrroSSHKeyConfigBasic(name, publicSSHKey string) string {

--- a/internal/resources/resource_volume.go
+++ b/internal/resources/resource_volume.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
 )
 
 const (

--- a/internal/resources/resource_volume_test.go
+++ b/internal/resources/resource_volume_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hpe-hcss/quake-client/pkg/terraform/configuration"
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/configuration"
 )
 
 func TestAccQuattroVolume(t *testing.T) {

--- a/internal/test-utils/test-provider.go
+++ b/internal/test-utils/test-provider.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/client"
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/registration"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/client"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/registration"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/provider"
 )
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	testutils "github.com/HewlettPackard/hpegl-metal-terraform-resources/internal/test-utils"
+	testutils "github.com/hewlettpackard/hpegl-metal-terraform-resources/internal/test-utils"
 )
 
 func main() {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/client"
 
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/configuration"
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/constants"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/configuration"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/constants"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 )
 
 // Assert that InitialiseClient satisfies the client.Initialisation interface

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/gltform"
 	"github.com/hewlettpackard/hpegl-provider-lib/pkg/token/retrieve"
 
-	rest "github.com/hpe-hcss/quake-client/v1/pkg/client"
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/pkg/constants"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/pkg/constants"
+	rest "github.com/hewlettpackard/hpegl-metal-client/v1/pkg/client"
 )
 
 // KeyForGLClientMap is used by the GL terraform provider to set the key in the

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -5,7 +5,7 @@ package registration
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/HewlettPackard/hpegl-metal-terraform-resources/internal/resources"
+	"github.com/hewlettpackard/hpegl-metal-terraform-resources/internal/resources"
 )
 
 const (


### PR DESCRIPTION
- Moved SDK reference to hpegl-metal-client instead of quake-client
- Changed org name in gitrepo paths from HewlettPackard to hewlettpackard