### PR TITLE
Prevent calculating any changes to hosts networks as host re-create

### DIFF
--- a/internal/resources/resource_host.go
+++ b/internal/resources/resource_host.go
@@ -118,7 +118,6 @@ func hostSchema() map[string]*schema.Schema {
 		hNetworks: {
 			Type:     schema.TypeList,
 			Required: true,
-			ForceNew: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},


### PR DESCRIPTION
From the TF side, whenever the host's networks are updated, the next 'terraform apply' is recreating the host as the 'ForceNew' attribute is 'true' here. This is not correct behavior, Server-side Host update implementation seems to support network updates dynamically. The TF plugin should call for Host Update instead of recreating whenever the network is updated.

Note: This will address the plan where Networks field change is seen as destroy-create action. However, the Host update via TF has not been implemented correctly. The function seems to do some calculations but in the end, doesn't make a Host Update API request call. 

