### PR TITLE
DE16637: [TF] host create fails when there is trailing slash in the URL

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -176,6 +176,7 @@ func NewConfig(portalURL string, opts ...CreateOpt) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("configuration error: %v", err)
 	}
+
 	cfg.BasePath = basePath
 
 	if config.useGLToken || config.trf != nil {

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 
 package configuration
 
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 
@@ -170,7 +171,12 @@ func NewConfig(portalURL string, opts ...CreateOpt) (*Config, error) {
 
 	// Get a new Client configuration with basepath set to Metal portal URL and add base version path /rest/v1
 	cfg := rest.NewConfiguration()
-	cfg.BasePath = config.restURL + "/rest/v1"
+
+	basePath, err := url.JoinPath(config.restURL, "/rest/v1")
+	if err != nil {
+		return nil, fmt.Errorf("configuration error: %v", err)
+	}
+	cfg.BasePath = basePath
 
 	if config.useGLToken || config.trf != nil {
 		if err := validateGLConfig(*config); err != nil {


### PR DESCRIPTION
[DE16637](https://rally1.rallydev.com/#/?detail=/defect/693899745361&fdp=true): [TF] host create fail when there is trailing slash in the URL