### PR TITLE
Update indirect yamux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
-	github.com/hashicorp/yamux v0.1.1 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTV
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
-github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
-github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hewlettpackard/hpegl-metal-client v1.5.32 h1:VKGPjnxoATNBhnkqysn/Hnvhkpzi+V8i9Jb2tyv/Y+M=
 github.com/hewlettpackard/hpegl-metal-client v1.5.32/go.mod h1:4fj/Mu7DbfuJhYorAP1lONuj8v+EXHh9cJxxGujf4HA=
 github.com/hewlettpackard/hpegl-provider-lib v0.0.22 h1:keW0HjvsMSvIyorqAKc1/XRHkIZqdGn8fqekeuVUSCc=


### PR DESCRIPTION
Indirect dependency yamux 0.1.1 is pulled in from the current version of terraform-plugin-sdk/v2. Until that packages is updated to pull in the current yamux, we are manually updating the indirect depenency.

This resolves https://github.com/HewlettPackard/hpegl-metal-terraform-resources/security/dependabot/5