### PR TITLE
PCCM-117030: Update Metal Terraform provider to support optional IPPool for Networks

### DIFF
--- a/internal/acceptance_test/resource_network_test.go
+++ b/internal/acceptance_test/resource_network_test.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2023, 2025 Hewlett Packard Enterprise Development LP
 
 package acceptance_test
 
@@ -77,6 +77,7 @@ resource "hpegl_metal_network" "pnet" {
   description        = "tf-net description"
   host_use           = "Default"
   purpose            = "Storage"
+  no_ip_pool         = true
 }`
 }
 

--- a/internal/resources/datasource_available_resources.go
+++ b/internal/resources/datasource_available_resources.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2023, 2025 Hewlett Packard Enterprise Development LP
 
 package resources
 
@@ -38,6 +38,7 @@ const (
 	nLocation    = "location"
 	nLocationID  = "location_id"
 	nIPPoolID    = "ip_pool_id"
+	nNoIPPool    = "no_ip_pool"
 
 	// For avMachineSizes each terraform block has these attributes.
 	sName        = "name"
@@ -451,6 +452,7 @@ func addNetworks(p *configuration.Config, d *schema.ResourceData, available rest
 			nPurpose:     net.Purpose,
 			nLocationID:  net.LocationID,
 			nIPPoolID:    net.IPPoolID,
+			nNoIPPool:    net.NoIPPool,
 			nVLAN:        net.VLAN,
 			nVNI:         net.VNI,
 		}

--- a/internal/resources/datasource_available_resources_test.go
+++ b/internal/resources/datasource_available_resources_test.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 
 package resources
 
@@ -13,8 +13,12 @@ import (
 )
 
 func Test_addNetworks(t *testing.T) {
-	testVlan := 200
-	testVni := 12006
+	const (
+		testVlan  = 200
+		testVni   = 12006
+		testVlan2 = 200
+		testVni2  = 12006
+	)
 
 	availableNets := client.AvailableResources{
 		Networks: []client.AvailableNetwork{
@@ -22,6 +26,12 @@ func Test_addNetworks(t *testing.T) {
 				ID:   "testID",
 				VLAN: int32(testVlan),
 				VNI:  int32(testVni),
+			},
+			{
+				ID:       "testID2",
+				VLAN:     int32(testVlan2),
+				VNI:      int32(testVni2),
+				NoIPPool: true,
 			},
 		},
 	}
@@ -38,11 +48,19 @@ func Test_addNetworks(t *testing.T) {
 
 	networks, ok := d.Get(avNetworks).([]interface{})
 	assert.True(t, ok, "type assertion failed for networks")
-	assert.Equal(t, 1, len(networks))
+	assert.Equal(t, 2, len(networks))
 
 	net, ok := networks[0].(map[string]interface{})
-	assert.True(t, ok, "type assertion failed for a network")
+	assert.True(t, ok, "type assertion failed for network 1")
 
 	assert.Equal(t, testVlan, net["vlan"])
 	assert.Equal(t, testVni, net["vni"])
+	assert.Equal(t, false, net["no_ip_pool"])
+
+	net, ok = networks[1].(map[string]interface{})
+	assert.True(t, ok, "type assertion failed for network 2")
+
+	assert.Equal(t, testVlan2, net["vlan"])
+	assert.Equal(t, testVni2, net["vni"])
+	assert.Equal(t, true, net["no_ip_pool"])
 }

--- a/internal/resources/resource_network.go
+++ b/internal/resources/resource_network.go
@@ -228,7 +228,10 @@ func resourceMetalNetworkCreate(d *schema.ResourceData, meta interface{}) (err e
 
 	var ippool *rest.NewIpPool
 
-	noIPPool := d.Get(nNoIPPool).(bool)
+	noIPPool, ok := d.Get(nNoIPPool).(bool)
+	if !ok {
+		return fmt.Errorf("%v is expected to be a bool", nNoIPPool)
+	}
 
 	if set, ok := d.Get(nIPPool).(*schema.Set); ok && len(set.List()) != 0 {
 		if noIPPool {
@@ -367,7 +370,7 @@ func resourceMetalNetworkRead(d *schema.ResourceData, meta interface{}) (err err
 	}
 
 	if err = d.Set(nPurpose, n.Purpose); err != nil {
-		// nolint:wrapcheck // defer func is wrapping the error.
+		//nolint:wrapcheck // defer func is wrapping the error.
 		return err
 	}
 
@@ -376,6 +379,7 @@ func resourceMetalNetworkRead(d *schema.ResourceData, meta interface{}) (err err
 	}
 
 	if err = d.Set(nNoIPPool, n.NoIPPool); err != nil {
+		//nolint:wrapcheck // defer func is wrapping the error.
 		return err
 	}
 


### PR DESCRIPTION
Requires Project API client version [v1.5.34](https://github.com/HewlettPackard/hpegl-metal-client/releases/tag/v1.5.34) or later.
Tested in simulator.