### PR TITLE
Fix Volume update size handling

### DIFF
--- a/internal/resources/resource_volume.go
+++ b/internal/resources/resource_volume.go
@@ -1,4 +1,4 @@
-// (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 package resources
 
@@ -477,7 +477,9 @@ func resourceMetalVolumeUpdate(d *schema.ResourceData, meta interface{}) (err er
 		ETag: vol.ETag,
 	}
 
-	updateVol.Capacity = int64(math.Round(newSize * GBToGiBConversion)) // convert from GB to GiB
+	// Although Project API for Volume create is in units of GiB,
+	// Volume get & update are in units of KiB.
+	updateVol.Capacity = int64(math.Round(newSize * KiBToGBConversion)) // convert from GB to KiB
 
 	// add tags
 	if m, ok := d.Get(vLabels).(map[string]interface{}); ok {


### PR DESCRIPTION
Project API for Volume Create is in units of GiB. Terraform stores Volume "Size" in units of GB. For Create, GB is converted to GiB, but for Update, GB needs to be converted to KiB. See quake [PR#5749](https://github.com/hpe-hcss/quake/pull/5749) for more details.

Note: this issue is currently blocking dependabot update of the Client API for Boot-from-SAN related changes (PR #266). Once this PR is merged, will update #266.